### PR TITLE
Hotfix/modify concurrency

### DIFF
--- a/tdd/src/main/java/io/hhplus/tdd/point/controller/PointController.java
+++ b/tdd/src/main/java/io/hhplus/tdd/point/controller/PointController.java
@@ -25,7 +25,7 @@ public class PointController {
      */
     @GetMapping("{id}")
     public ResponseEntity<UserPointResponse> point(
-            @PathVariable long id
+            @PathVariable(name = "id") long id
     ) {
         return ResponseEntity.ok(pointService.getPoint(id));
     }
@@ -35,7 +35,7 @@ public class PointController {
      */
     @GetMapping("{id}/histories")
     public ResponseEntity<List<PointHistoryResponse>> history(
-            @PathVariable long id
+            @PathVariable(name = "id") long id
     ) {
         return ResponseEntity.ok(pointService.getHistories(id));
     }
@@ -45,7 +45,7 @@ public class PointController {
      */
     @PatchMapping("{id}/charge")
     public ResponseEntity<UserPointResponse> charge(
-            @PathVariable long id,
+            @PathVariable(name = "id") long id,
             @RequestBody long amount
     ) {
         return ResponseEntity.ok(pointService.charge(id, amount));
@@ -56,7 +56,7 @@ public class PointController {
      */
     @PatchMapping("{id}/use")
     public ResponseEntity<UserPointResponse> use(
-            @PathVariable long id,
+            @PathVariable(name = "id") long id,
             @RequestBody long amount
     ) {
         return ResponseEntity.ok(pointService.use(id, amount));


### PR DESCRIPTION
### 변경사항
- Lock만 사용시 "행위"에 대한 제어가 이루어진다. 유저별 제어를 위해 ConcurrentHashMap 다시 추가
- controller 테스트시 id가 명시되지 않아 실패하는 부분 수정